### PR TITLE
some rendering optimizations

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,18 @@ var quarks = [];
 var canvasSize = innerHeight*0.935;
 var maxCanvasPos;
 
-// canvas
-function screenUpdate() {
-  // set canvas size
+// set canvas size
+canvas.width = (innerWidth-innerHeight*0.005)*0.8;
+canvas.height = innerHeight*0.935;
+canvasSize = Math.min(canvas.width, canvas.height);
+maxCanvasPos = [
+  ((canvas.width-Math.max(0, (canvas.width-canvasSize)/2))/canvasSize)*2-1,
+  (((canvas.height)-Math.max(0, (canvas.height-canvasSize)/2))/canvasSize)*2-1
+];
+
+// reset canvas size upon window resize
+// TODO: scale canvas with CSS instead for better performance
+window.onresize = function resizeCanvas () {
   canvas.width = (innerWidth-innerHeight*0.005)*0.8;
   canvas.height = innerHeight*0.935;
   canvasSize = Math.min(canvas.width, canvas.height);
@@ -18,7 +27,9 @@ function screenUpdate() {
     ((canvas.width-Math.max(0, (canvas.width-canvasSize)/2))/canvasSize)*2-1,
     (((canvas.height)-Math.max(0, (canvas.height-canvasSize)/2))/canvasSize)*2-1
   ];
+}
 
+function screenUpdate() {
   // clear canvas
   c.clearRect(0, 0, canvas.width, canvas.height);
   c.beginPath();

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 // init1
 var canvas = document.querySelector("#canvas");
-var c = canvas.getContext("2d");
+var c = canvas.getContext("2d", {alpha: false});
 var sessionTickSpent = 0;
 var quarks = [];
 var canvasSize = innerHeight*0.935;

--- a/index.js
+++ b/index.js
@@ -418,7 +418,9 @@ var tickSpeed = 20;
 var autoClickCharge = 0;
 setInterval( function () {
   screenUpdate();
-  displayUpgrade();
+  if (sessionTickSpent % 5 === 0) {
+    displayUpgrade();
+  }
   sessionTickSpent++;
   game.tickSpent++;
   if (sessionTickSpent%100 === 0) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 // init1
 var canvas = document.querySelector("#canvas");
-var c = canvas.getContext("2d", {alpha: false});
+var onscreenC = canvas.getContext("2d", {alpha: false});
 var sessionTickSpent = 0;
 var quarks = [];
 var canvasSize = innerHeight*0.935;
@@ -17,11 +17,19 @@ maxCanvasPos = [
   (((canvas.height)-Math.max(0, (canvas.height-canvasSize)/2))/canvasSize)*2-1
 ];
 
+// init offscreen canvas
+var offscreenCanvas = document.createElement("canvas");
+offscreenCanvas.width = canvas.width;
+offscreenCanvas.height = canvas.height;
+var c = offscreenCanvas.getContext("2d", {alpha: false});
+
 // reset canvas size upon window resize
 // TODO: scale canvas with CSS instead for better performance
 window.onresize = function resizeCanvas () {
   canvas.width = (innerWidth-innerHeight*0.005)*0.8;
   canvas.height = innerHeight*0.935;
+  offscreenCanvas.width = canvas.width;
+  offscreenCanvas.height = canvas.height;
   canvasSize = Math.min(canvas.width, canvas.height);
   maxCanvasPos = [
     ((canvas.width-Math.max(0, (canvas.width-canvasSize)/2))/canvasSize)*2-1,

--- a/index.js
+++ b/index.js
@@ -103,6 +103,9 @@ function screenUpdate() {
     var txtToWrite = `You beat the game! Thanks for playing!`;
     c.fillText(txtToWrite, canvas.width/2-c.measureText((txtToWrite).toString()).width/2, canvas.height/2);
   }
+  
+  // finally draw to the onscreen canvas
+  onscreenC.drawImage(offscreenCanvas, 0, 0);
 }
 
 // saveload


### PR DESCRIPTION
Per MDN,

> If your application uses canvas and doesn’t need a transparent backdrop, set the alpha option to false when creating a drawing context with HTMLCanvasElement.getContext(). This information can be used internally by the browser to optimize rendering.

(https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas)